### PR TITLE
Encryption can decrypt not json strings

### DIFF
--- a/src/Security/Encryption.php
+++ b/src/Security/Encryption.php
@@ -53,7 +53,6 @@ class Encryption implements LoggerAwareInterface
         if (null == $iv) {
             $iv_len = openssl_cipher_iv_length($this->method);
             $iv = openssl_random_pseudo_bytes($iv_len);
-            var_dump($iv);
         }
 
         $this->password = $password;

--- a/src/Security/Encryption.php
+++ b/src/Security/Encryption.php
@@ -53,6 +53,7 @@ class Encryption implements LoggerAwareInterface
         if (null == $iv) {
             $iv_len = openssl_cipher_iv_length($this->method);
             $iv = openssl_random_pseudo_bytes($iv_len);
+            var_dump($iv);
         }
 
         $this->password = $password;
@@ -100,7 +101,10 @@ class Encryption implements LoggerAwareInterface
             $options,
             $this->iv
         );
-        $result = json_decode(rtrim($result, "\0"), true);
+        $result = rtrim($result, "\0");
+
+        $decodedJson = json_decode($result, true);
+        $result = null!==$decodedJson ? $decodedJson : $result;
 
         $this->logger->debug('Uncrypting message', [$message, $result]);
 

--- a/tests/Security/EncryptionTest.php
+++ b/tests/Security/EncryptionTest.php
@@ -16,14 +16,25 @@ use Mediapart\LaPresseLibre\Security\Encryption;
 
 class EncryptionTest extends TestCase
 {
-    public function testEncrypt()
+    public function testEncryption()
     {
         $string = 'lorem ipsum dolor';
-        $encryption = new Encryption('passphrase');
+        $encryption = new Encryption('passphrase', '8265408651542848', 0);
 
         $encrypted = $encryption->encrypt($string);
-        $decrypted = $encryption->decrypt($string);
+        $decrypted = $encryption->decrypt($encrypted);
 
-        $this->assertEquals($encrypted, $decrypted);
+        $this->assertEquals('UVZVTXBlNnBsSy9Ea2lsai8zRjZreElvbHAxeW0rVm1rcmRzNi9nQ2lKYz0=', $encrypted);
+        $this->assertEquals($string, $decrypted);
+    }
+
+    public function testNotJsonStringDecryption()
+    {
+    	$encrypted = 'VHZoeHhsdjgwV3RsODVVcEd5ak1MaWc3UlJFRnF6Ly9IemtWSUlWcjJlMD0=';
+
+        $encryption = new Encryption('passphrase', '8265408651542848', 0);
+        $decrypted = $encryption->decrypt($encrypted);
+
+        $this->assertEquals('lorem ipsum dolor', $decrypted);
     }
 }

--- a/tests/Security/EncryptionTest.php
+++ b/tests/Security/EncryptionTest.php
@@ -37,4 +37,15 @@ class EncryptionTest extends TestCase
 
         $this->assertEquals('lorem ipsum dolor', $decrypted);
     }
+
+    public function testIv()
+    {
+    	$string = 'loremp ipsum dolor';
+
+        $encryption = new Encryption('passphrase', null, 0);
+        $encrypted = $encryption->encrypt($string);
+
+        $this->assertNotEquals('', $encrypted);
+        $this->assertNotEquals($string, $encrypted);
+    }
 }


### PR DESCRIPTION
In [Liaison use case](https://github.com/NextINpact/LaPresseLibreSDK/wiki/Liaison-de-compte-utilisateur-par-redirection), the `lplUser` param is an encrypted string but not using JSON format.

This PR adds the ability to decrypt strings not using JSON format.